### PR TITLE
add repository to package.json to fix no repository warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stefanpenner/ember-cli-auto-register-helpers.git"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
fixes this warning from happening when running npm install 

```
npm WARN package.json ember-cli-auto-register-helpers@1.0.0 No repository field.
```
